### PR TITLE
be more specific about copying the contents of the blank directory

### DIFF
--- a/main.go
+++ b/main.go
@@ -67,7 +67,7 @@ func main() {
 
 	// 2. Copy everything under blank directory to target directory.
 	log.Print("Copying a blank project to " + fullpath + "...")
-	if output, err := exec.Command("cp", "-rf", "./blank/", fullpath).CombinedOutput(); err != nil {
+	if output, err := exec.Command("cp", "-rf", "./blank/.", fullpath).CombinedOutput(); err != nil {
 		log.Fatal(string(output))
 	}
 


### PR DESCRIPTION
This addresses https://github.com/go-bootstrap/go-bootstrap/issues/10

`cp` handles copying a directory's contents differently on OSX than in Linux. On OSX, it copies the contents of the directory whereas on Linux it copies the directory itself.
