### PR TITLE
Fix recursive copy pathing

### DIFF
--- a/helpers/helpers.go
+++ b/helpers/helpers.go
@@ -6,6 +6,7 @@ import (
 	"crypto/rand"
 	"fmt"
 	"io/ioutil"
+	"log"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -82,3 +83,15 @@ func DefaultPGDSN(dbName string) string {
 
 	return fmt.Sprintf("postgres://%v@%v%v%v/%v?sslmode=%v", pguser, pghost, hostPortSeparator, pgport, dbName, pgsslmode)
 }
+
+func ChDir(dir string) {
+	err := os.Chdir(dir)
+	ExitOnError(err, "")
+}
+
+func ExitOnError(err error, msg string) {
+	if err != nil {
+		log.Fatalf("%s\n%s", msg, err.Error())
+	}
+}
+

--- a/main.go
+++ b/main.go
@@ -101,9 +101,8 @@ func main() {
 	log.Print("Running go get ./...")
 	cmd := exec.Command("go", "get", "./...")
 	cmd.Dir = fullpath
-	if output, err := cmd.CombinedOutput(); err != nil {
-		log.Fatal(string(output))
-	}
+	output, err = cmd.CombinedOutput()
+	exitOnError(err, string(output))
 
 	repoIsGit := strings.HasPrefix(repoName, "git")
 
@@ -117,7 +116,7 @@ func main() {
 		log.Print("Running git init")
 		cmd := exec.Command("git", "init")
 		cmd.Dir = fullpath
-		output, err := cmd.CombinedOutput()
+		output, err = cmd.CombinedOutput()
 		exitOnError(err, string(output))
 
 		// godep save ./...

--- a/main.go
+++ b/main.go
@@ -12,6 +12,17 @@ import (
 	"strings"
 )
 
+func chDir(dir string) {
+	err := os.Chdir(dir)
+	exitOnError(err, "")
+}
+
+func exitOnError(err error, msg string) {
+	if err != nil {
+		log.Fatalf("%s\n%s", msg, err.Error())
+	}
+}
+
 func main() {
 	dir := flag.String("dir", "", "Project directory relative to $GOPATH/src/")
 	flag.Parse()
@@ -37,15 +48,20 @@ func main() {
 	// 1. Create target directory
 	log.Print("Creating " + fullpath + "...")
 	err := os.MkdirAll(fullpath, 0755)
-	if err != nil {
-		log.Fatal(err)
-	}
+	exitOnError(err, "")
 
 	// 2. Copy everything under blank directory to target directory.
 	log.Print("Copying a blank project to " + fullpath + "...")
-	if output, err := exec.Command("cp", "-rf", "./blank/.", fullpath).CombinedOutput(); err != nil {
-		log.Fatal(string(output))
-	}
+	blankDir := os.ExpandEnv(filepath.Join("$GOPATH", "src", "github.com", "go-bootstrap", "go-bootstrap", "blank"))
+	currDir, err := os.Getwd()
+	exitOnError(err, "Can't get current path!")
+
+	chDir(blankDir)
+
+	output, err := exec.Command("cp", "-rf", ".", fullpath).CombinedOutput()
+	exitOnError(err, string(output))
+
+	chDir(currDir)
 
 	// 3. Interpolate placeholder variables on the new project.
 	log.Print("Replacing placeholder variables on " + repoUser + "/" + projectName + "...")
@@ -56,9 +72,8 @@ func main() {
 	replacers["$GO_BOOTSTRAP_COOKIE_SECRET"] = helpers.RandString(16)
 	replacers["$GO_BOOTSTRAP_CURRENT_USER"] = currentUser.Username
 	replacers["$GO_BOOTSTRAP_DOCKERFILE_DSN"] = helpers.DefaultPGDSN(dbName)
-	if err := helpers.RecursiveSearchReplaceFiles(fullpath, replacers); err != nil {
-		log.Fatal(err)
-	}
+	err = helpers.RecursiveSearchReplaceFiles(fullpath, replacers)
+	exitOnError(err, "")
 
 	// 4. Create PostgreSQL databases.
 	for _, name := range []string{dbName, testDbName} {
@@ -70,18 +85,16 @@ func main() {
 
 	// 5.a. go get github.com/mattes/migrate.
 	log.Print("Installing github.com/mattes/migrate...")
-	if output, err := exec.Command("go", "get", "github.com/mattes/migrate").CombinedOutput(); err != nil {
-		log.Fatal(string(output))
-	}
+	output, err = exec.Command("go", "get", "github.com/mattes/migrate").CombinedOutput()
+	exitOnError(err, string(output))
 
 	// 5.b. Run migrations on localhost:5432.
 	for _, name := range []string{dbName, testDbName} {
 		pgDSN := helpers.DefaultPGDSN(name)
 
 		log.Print("Running database migrations on " + pgDSN + "...")
-		if output, err := exec.Command("migrate", "-url", pgDSN, "-path", migrationsPath, "up").CombinedOutput(); err != nil {
-			log.Fatal(string(output))
-		}
+		output, err := exec.Command("migrate", "-url", pgDSN, "-path", migrationsPath, "up").CombinedOutput()
+		exitOnError(err, string(output))
 	}
 
 	// 6. Get all application dependencies for the first time.
@@ -97,31 +110,28 @@ func main() {
 	if repoIsGit {
 		// Generate Godeps directory. Currently only works on git related repo.
 		log.Print("Installing github.com/tools/godep...")
-		if output, err := exec.Command("go", "get", "github.com/tools/godep").CombinedOutput(); err != nil {
-			log.Fatal(string(output))
-		}
+		output, err := exec.Command("go", "get", "github.com/tools/godep").CombinedOutput()
+		exitOnError(err, string(output))
 
 		// git init.
 		log.Print("Running git init")
 		cmd := exec.Command("git", "init")
 		cmd.Dir = fullpath
-		if output, err := cmd.CombinedOutput(); err != nil {
-			log.Fatal(string(output))
-		}
+		output, err = cmd.CombinedOutput()
+		exitOnError(err, string(output))
 
 		// godep save ./...
 		log.Print("Running godep save ./...")
 		cmd = exec.Command("godep", "save", "./...")
 		cmd.Dir = fullpath
-		if output, err := cmd.CombinedOutput(); err != nil {
-			log.Fatal(string(output))
-		}
+		output, err = cmd.CombinedOutput()
+		exitOnError(err, string(output))
 
 		// Run tests on newly generated app.
 		log.Print("Running godep go test ./...")
 		cmd = exec.Command("godep", "go", "test", "./...")
 		cmd.Dir = fullpath
-		output, _ := cmd.CombinedOutput()
+		output, _ = cmd.CombinedOutput()
 		log.Print(string(output))
 
 	} else {

--- a/main.go
+++ b/main.go
@@ -117,7 +117,7 @@ func main() {
 		log.Print("Running git init")
 		cmd := exec.Command("git", "init")
 		cmd.Dir = fullpath
-		output, err = cmd.CombinedOutput()
+		output, err := cmd.CombinedOutput()
 		exitOnError(err, string(output))
 
 		// godep save ./...
@@ -139,7 +139,7 @@ func main() {
 		log.Print("Running go test ./...")
 		cmd = exec.Command("go", "test", "./...")
 		cmd.Dir = fullpath
-		output, _ := cmd.CombinedOutput()
+		output, _ = cmd.CombinedOutput()
 		log.Print(string(output))
 	}
 }


### PR DESCRIPTION
This didn't run for me out of the box and it was because the `./blank/.` path was blowing up. This code gets around the issue by changing paths. It works both on OSX and Linux. Along the way I added a couple of utility functions including one to handle all the error checking and exiting. If you hate that I'll rebase with just the pathing change.

Awesome work @didip 