### PR TITLE
GOPATH's multiple paths

### DIFF
--- a/helpers/helpers_test.go
+++ b/helpers/helpers_test.go
@@ -6,6 +6,24 @@ import (
 	"testing"
 )
 
+func TestGoPaths(t *testing.T) {
+	os.Setenv("GOPATH", "/foo:/bar")
+	gopaths := GoPaths()
+	if len(gopaths) != 2 || gopaths[0] != "/foo" || gopaths[1] != "/bar" {
+		t.Errorf("Incorrectly split GOPATH. Output: %v", gopaths)
+	}
+}
+
+func TestIsValidGoPath(t *testing.T) {
+	os.Setenv("GOPATH", "/foo:/bar")
+	if !IsValidGoPath("/foo") {
+		t.Errorf("Valid GOPATH not recognized: /foo")
+	}
+	if IsValidGoPath("/baz") {
+		t.Errorf("Invalid GOPATH recognized as valid: /baz")
+	}
+}
+
 func TestBashEscape(t *testing.T) {
 	os.Setenv("PGPASSWORD", "boo")
 	dbName := DefaultPGDSN("default")


### PR DESCRIPTION
```
bo-mbp:bo [~/src/go/src]I> go-bootstrap -dir foobar/
2015/05/12 14:47:20 Creating /Users/bo/.gocode/src/foobar...
2015/05/12 14:47:20 Copying a blank project to /Users/bo/.gocode/src/foobar...
2015/05/12 14:47:20
chdir /Users/bo/.gocode:/Users/bo/src/go/src/github.com/go-bootstrap/go-bootstrap/blank: no such file or directory
```
My `$GOPATH` contains a list of paths, so everything I `go get` ends up in the first one, everything I do myself is located in the second. So when I `go get` go-bootstrap, it's in ~/.gocode/, but when I want it to create a new project, it should be in ~/src/go/.

So the error is in [main.go#L43][1], this should use the `gopath` variable. But before I change stuff I wanted to check back if you'd be ok with `-dir` being a relative path to the *last* part of `$GOPATH`. Maybe we can even check if `$PWD` is inside of a part and use that one.

What do you think?

[1]: https://github.com/go-bootstrap/go-bootstrap/blob/b5ccd89ab3571490eb7cdb7c681f1feca1eb9d4f/main.go#L43
