### PR TITLE
check for return error on ListenAndServe()

### DIFF
--- a/blank/main.go
+++ b/blank/main.go
@@ -113,8 +113,11 @@ func main() {
 
 	logrus.Infoln("Running HTTP server on "+ serverAddress)
 	if certFile != "" && keyFile != "" {
-		srv.ListenAndServeTLS(certFile, keyFile)
+		err = srv.ListenAndServeTLS(certFile, keyFile)
 	} else {
-		srv.ListenAndServe()
+		err = srv.ListenAndServe()
+	}
+	if err != nil {
+		logrus.Fatal(err.Error())
 	}
 }


### PR DESCRIPTION
When ListenAndServe() fails you currently don't see an error. With this PR you see the error when it fails.