### PR TITLE
Replace mattes/migrate with rnubel/pgmgr

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,6 @@ This generator makes **A LOT** of decisions for you. Here's the list of things i
 
 15. [github.com/tylerb/graceful](https://github.com/tylerb/graceful) is chosen to enable graceful shutdown.
 
-16. [github.com/mattes/migrate](https://github.com/mattes/migrate) is chosen as the database migration tool.
+16. [github.com/rnubel/pgmgr](https://github.com/rnubel/pgmgr) is chosen as the database migration and management tool.
 
 17. [github.com/Sirupsen/logrus](https://github.com/Sirupsen/logrus) is chosen as the logging library.

--- a/blank/.pgmgr.json
+++ b/blank/.pgmgr.json
@@ -1,0 +1,1 @@
+{ "url": "$GO_BOOTSTRAP_PG_DSN", "migration-folder": "migrations", "dump-file": "migrations/dump.sql", "seed-tables": [] }

--- a/blank/.pgmgr.test.json
+++ b/blank/.pgmgr.test.json
@@ -1,0 +1,1 @@
+{ "url": "$GO_BOOTSTRAP_PG_TEST_DSN", "migration-folder": "migrations", "dump-file": "migrations/dump.sql", "seed-tables": [] }

--- a/blank/README.md
+++ b/blank/README.md
@@ -4,21 +4,21 @@
 
 2. Install Go 1.4.x, git, setup `$GOPATH`, and `PATH=$PATH:$GOPATH/bin`
 
-3. Create PostgreSQL database.
-    ```
-    createdb $GO_BOOTSTRAP_PROJECT_NAME
-    ```
-
-4. Get the source code.
+3. Get the source code.
     ```
     go get $GO_BOOTSTRAP_REPO_NAME/$GO_BOOTSTRAP_REPO_USER/$GO_BOOTSTRAP_PROJECT_NAME
     ```
 
+4. Create PostgreSQL database.
+    ```
+    cd $GOPATH/src/$GO_BOOTSTRAP_REPO_NAME/$GO_BOOTSTRAP_REPO_USER/$GO_BOOTSTRAP_PROJECT_NAME
+    go get github.com/rnubel/pgmgr
+    pgmgr db create
+    ```
+
 5. Run the PostgreSQL migration.
     ```
-    go get github.com/mattes/migrate
-    cd $GOPATH/src/$GO_BOOTSTRAP_REPO_NAME/$GO_BOOTSTRAP_REPO_USER/$GO_BOOTSTRAP_PROJECT_NAME
-    migrate -url postgres://$(whoami)@$localhost:5432/$GO_BOOTSTRAP_PROJECT_NAME?sslmode=disable -path ./migrations up
+    pgmgr db migrate
     ```
 
 6. Run the server
@@ -45,30 +45,30 @@
 
 ## Running Migrations
 
-Migration is handled by a separate project: [github.com/mattes/migrate](https://github.com/mattes/migrate).
+Migration is handled by a separate project: [github.com/rnubel/pgmgr](https://github.com/rnubel/pgmgr).
 
-Here's a quick tutorial on how to use it. For more details, read the tutorial [here](https://github.com/mattes/migrate#usage-from-terminal).
+Here's a quick tutorial on how to use it. For more details, read the tutorial [here](https://github.com/rnubel/pgmgr#usage).
 ```
 # Installing the library
-go get github.com/mattes/migrate
+go get github.com/rnubel/pgmgr
 
 # Create a new migration file
-migrate -url driver://url -path ./migrations create {filename}
+pgmgr migration {filename}
 
 # Migrate all the way up
-migrate -url driver://url -path ./migrations up
+pgmgr db migrate
 
-# Migrate all the way down
-migrate -url driver://url -path ./migrations down
+# Reset to the latest dump
+pgmgr db drop
+pgmgr db create
+pgmgr db load
 
 # Roll back the most recently applied migration, then run it again.
-migrate -url driver://url -path ./migrations redo
+pgmgr db rollback
+pgmgr db migrate
 
-# Run down and then up command
-migrate -url driver://url -path ./migrations reset
-
-# Show the current migration version
-migrate -url driver://url -path ./migrations version
+# Show the latest migration version
+pgmgr db version
 ```
 
 

--- a/blank/scripts/db-bootstrap
+++ b/blank/scripts/db-bootstrap
@@ -1,13 +1,13 @@
 #!/usr/bin/env bash
 
 echo "Creating database $GO_BOOTSTRAP_PROJECT_NAME..."
-createdb $GO_BOOTSTRAP_PROJECT_NAME
+pgmgr db create
 
-echo "Running migration on $GO_BOOTSTRAP_PG_DSN..."
-migrate -url $GO_BOOTSTRAP_ESCAPED_PG_DSN -path ./migrations up
+echo "Running migrations..."
+pgmgr db migrate
 
 echo "Creating database $GO_BOOTSTRAP_PROJECT_NAME-test"
-createdb $GO_BOOTSTRAP_PROJECT_NAME-test
+pgmgr -c ".pgmgr.test.json" db create
 
 echo "Running migration on $GO_BOOTSTRAP_PG_TEST_DSN..."
-migrate -url $GO_BOOTSTRAP_ESCAPED_PG_TEST_DSN -path ./migrations up
+pgmgr -c ".pgmgr.test.json" db migrate

--- a/main.go
+++ b/main.go
@@ -97,9 +97,9 @@ func main() {
 	err = helpers.RecursiveSearchReplaceFiles(fullpath, replacers)
 	helpers.ExitOnError(err, "")
 
-	// 4. go get github.com/mattes/migrate.
-	log.Print("Running go get github.com/mattes/migrate...")
-	output, err = exec.Command("go", "get", "github.com/mattes/migrate").CombinedOutput()
+	// 4. go get github.com/rnubel/pgmgr
+	log.Print("Running go get github.com/rnubel/pgmgr...")
+	output, err = exec.Command("go", "get", "github.com/rnubel/pgmgr").CombinedOutput()
 	helpers.ExitOnError(err, string(output))
 
 	// 5. Bootstrap databases.


### PR DESCRIPTION
:construction:

[pgmgr](http://github.com/rnubel/pgmgr) (Postgres Manager) is a similar tool to migrate, but it has several advantages which I (granted, being a bit biased :wink:) believe make it a better choice for this project:

1. It does not depend on sqlite3, which there have been several issues
   with already (#29, #8). It only uses pq and core Postgres tooling.
2. It supports dumping and loading of the database schema, which is
   essential for application development in a large team with real
   production apps.
3. It's easier to use (see the usage instructions in `blank/README.md`). Migrate requires the configuration to be passed
   via command-line arguments every time you use it. Pgmgr can use a
   configuration file, environment variables, or command-line arguments,
   which makes it usable in any situation.
4. Migration versions are based on Unix timestamps, not an incrementing
   integer. This makes things much easier when you have multiple developers
   working on the same project.
5. It's backwards-compatible with migrations generated by migrate.

However, pgmgr has not been production-tested, nor even used in any real apps yet. It may well need changes or further testing before it's suitable for inclusion in this project. Let me know what your thoughts are.