### PR TITLE
Use 302 redirects for user mgmt instead of 301.

### DIFF
--- a/blank/handlers/home.go
+++ b/blank/handlers/home.go
@@ -17,7 +17,7 @@ func GetHome(w http.ResponseWriter, r *http.Request) {
 	session, _ := cookieStore.Get(r, "$GO_BOOTSTRAP_PROJECT_NAME-session")
 	currentUser, ok := session.Values["user"].(*dal.UserRow)
 	if !ok {
-		http.Redirect(w, r, "/logout", 301)
+		http.Redirect(w, r, "/logout", 302)
 		return
 	}
 

--- a/blank/handlers/users.go
+++ b/blank/handlers/users.go
@@ -65,7 +65,7 @@ func GetLogin(w http.ResponseWriter, r *http.Request) {
 
 	currentUserInterface := session.Values["user"]
 	if currentUserInterface != nil {
-		http.Redirect(w, r, "/", 301)
+		http.Redirect(w, r, "/", 302)
 		return
 	}
 
@@ -99,7 +99,7 @@ func PostLogin(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	http.Redirect(w, r, "/", 301)
+	http.Redirect(w, r, "/", 302)
 }
 
 func GetLogout(w http.ResponseWriter, r *http.Request) {
@@ -112,7 +112,7 @@ func GetLogout(w http.ResponseWriter, r *http.Request) {
 	delete(session.Values, "user")
 	session.Save(r, w)
 
-	http.Redirect(w, r, "/login", 301)
+	http.Redirect(w, r, "/login", 302)
 }
 
 func PostPutDeleteUsersID(w http.ResponseWriter, r *http.Request) {
@@ -167,7 +167,7 @@ func PutUsersID(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	http.Redirect(w, r, "/", 301)
+	http.Redirect(w, r, "/", 302)
 }
 
 func DeleteUsersID(w http.ResponseWriter, r *http.Request) {

--- a/blank/middlewares/middlewares.go
+++ b/blank/middlewares/middlewares.go
@@ -2,10 +2,11 @@
 package middlewares
 
 import (
+	"net/http"
+
 	"github.com/gorilla/context"
 	"github.com/gorilla/sessions"
 	"github.com/jmoiron/sqlx"
-	"net/http"
 )
 
 func SetDB(db *sqlx.DB) func(http.Handler) http.Handler {
@@ -36,7 +37,7 @@ func MustLogin(next http.Handler) http.Handler {
 		userRowInterface := session.Values["user"]
 
 		if userRowInterface == nil {
-			http.Redirect(res, req, "/login", 301)
+			http.Redirect(res, req, "/login", 302)
 			return
 		}
 


### PR DESCRIPTION
301 is cacheable. I ended up in a weird state where all /logout requests were
turning into requests for / without hitting my server, because firefox was
caching them.  I'm fairly confident 301 shouldn't be used, but I'm not as sure 302 is ideal.