### PR TITLE
Use USERNAME environment variable (fixes #33)

### DIFF
--- a/helpers/helpers.go
+++ b/helpers/helpers.go
@@ -119,8 +119,7 @@ func DefaultPGDSN(dbName string) string {
 	hostPortSeparator := ":"
 
 	if pguser == "" {
-		u, _ := user.Current()
-		pguser = u.Username
+		pguser = GetCurrentUser()
 	}
 
 	isUnixDomainSocket := strings.HasPrefix(pghost, "/")
@@ -152,5 +151,22 @@ func DefaultPGDSN(dbName string) string {
 func ExitOnError(err error, msg string) {
 	if err != nil {
 		log.Fatalf("%s\n%s", msg, err.Error())
+	}
+}
+
+// GetCurrentUser returns the username of the current user.
+func GetCurrentUser() string {
+	currentUser, err := user.Current()
+
+	if err == nil {
+		return currentUser.Username
+	} else {
+		username := os.Getenv("USERNAME")
+
+		if username == "" {
+			log.Fatalln("Cannot determine current user's username")
+		}
+
+		return username
 	}
 }

--- a/main.go
+++ b/main.go
@@ -6,7 +6,6 @@ import (
 	"log"
 	"os"
 	"os/exec"
-	"os/user"
 	"path/filepath"
 	"strings"
 
@@ -56,20 +55,6 @@ func main() {
 	projectName := dirChunks[len(dirChunks)-1]
 	dbName := projectName
 	testDbName := projectName + "-test"
-
-	var userName string
-	currentUser, err := user.Current()
-
-	if err == nil {
-		userName = currentUser.Username
-	} else {
-		userName = os.Getenv("USERNAME")
-
-		if userName == "" {
-			log.Fatalln("Cannot determine current user's username")
-		}
-	}
-
 	blankDir, err := helpers.GetBlankDir()
 	helpers.ExitOnError(err, "")
 
@@ -100,7 +85,7 @@ func main() {
 	replacers["$GO_BOOTSTRAP_REPO_USER"] = repoUser
 	replacers["$GO_BOOTSTRAP_PROJECT_NAME"] = projectName
 	replacers["$GO_BOOTSTRAP_COOKIE_SECRET"] = helpers.RandString(16)
-	replacers["$GO_BOOTSTRAP_CURRENT_USER"] = userName
+	replacers["$GO_BOOTSTRAP_CURRENT_USER"] = helpers.GetCurrentUser()
 	replacers["$GO_BOOTSTRAP_PG_DSN"] = helpers.DefaultPGDSN(dbName)
 	replacers["$GO_BOOTSTRAP_ESCAPED_PG_DSN"] = helpers.BashEscape(helpers.DefaultPGDSN(dbName))
 	replacers["$GO_BOOTSTRAP_PG_TEST_DSN"] = helpers.DefaultPGDSN(testDbName)

--- a/main.go
+++ b/main.go
@@ -56,7 +56,19 @@ func main() {
 	projectName := dirChunks[len(dirChunks)-1]
 	dbName := projectName
 	testDbName := projectName + "-test"
-	currentUser, _ := user.Current()
+
+	var userName string
+	currentUser, err := user.Current()
+
+	if err == nil {
+		userName = currentUser.Username
+	} else {
+		userName = os.Getenv("USERNAME")
+
+		if userName == "" {
+			log.Fatalln("Cannot determine current user's username")
+		}
+	}
 
 	blankDir, err := helpers.GetBlankDir()
 	helpers.ExitOnError(err, "")
@@ -88,7 +100,7 @@ func main() {
 	replacers["$GO_BOOTSTRAP_REPO_USER"] = repoUser
 	replacers["$GO_BOOTSTRAP_PROJECT_NAME"] = projectName
 	replacers["$GO_BOOTSTRAP_COOKIE_SECRET"] = helpers.RandString(16)
-	replacers["$GO_BOOTSTRAP_CURRENT_USER"] = currentUser.Username
+	replacers["$GO_BOOTSTRAP_CURRENT_USER"] = userName
 	replacers["$GO_BOOTSTRAP_PG_DSN"] = helpers.DefaultPGDSN(dbName)
 	replacers["$GO_BOOTSTRAP_ESCAPED_PG_DSN"] = helpers.BashEscape(helpers.DefaultPGDSN(dbName))
 	replacers["$GO_BOOTSTRAP_PG_TEST_DSN"] = helpers.DefaultPGDSN(testDbName)


### PR DESCRIPTION
When user.Current() is not implemented on a given platform, use the USERNAME environment
variable instead.