### PR TITLE
updated ordered list syntax in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,17 +14,17 @@ Feel free to use or rip-out any of its parts.
 
 1. PostgreSQL or MySQL if you choose to use a database.
 
-2. Go programming language, version 1.3.x or newer.
+1. Go programming language, version 1.3.x or newer.
 
-3. Ensure `$GOPATH/bin` is in your `$PATH`. Example: `PATH=$PATH:$GOPATH/bin`
+1. Ensure `$GOPATH/bin` is in your `$PATH`. Example: `PATH=$PATH:$GOPATH/bin`
 
 ## Installation
 
 1. `go get github.com/go-bootstrap/go-bootstrap`
 
-2. `$GOPATH/bin/go-bootstrap -dir github.com/{git-user}/{project-name} -template {core|postgresql|mysql}`
+1. `$GOPATH/bin/go-bootstrap -dir github.com/{git-user}/{project-name} -template {core|postgresql|mysql}`
 
-3. Start using it: `cd $GOPATH/src/github.com/{git-user}/{project-name} && go run main.go`
+1. Start using it: `cd $GOPATH/src/github.com/{git-user}/{project-name} && go run main.go`
 
 
 ## PostgreSQL Environment Variables
@@ -45,36 +45,36 @@ This generator makes **A LOT** of decisions for you. Here's the list of things i
 
     * MySQL.
 
-2. bcrypt is chosen as the password hasher.
+1. bcrypt is chosen as the password hasher.
 
-3. Bootstrap Flatly is chosen for the UI theme.
+1. Bootstrap Flatly is chosen for the UI theme.
 
-4. Session is stored inside encrypted cookie.
+1. Session is stored inside encrypted cookie.
 
-5. Static directory is located under `/static`.
+1. Static directory is located under `/static`.
 
-6. Model directory is located under `/models`.
+1. Model directory is located under `/models`.
 
-7. It does not use a full blown ORM.
+1. It does not use a full blown ORM.
 
-8. Test database is automatically created under `$GO_BOOTSTRAP_PROJECT_NAME-test`.
+1. Test database is automatically created under `$GO_BOOTSTRAP_PROJECT_NAME-test`.
 
-9. A minimal Dockerfile is provided.
+1. A minimal Dockerfile is provided.
 
-10. A minimal Vagrantfile is provided.
+1. A minimal Vagrantfile is provided.
 
-11. [github.com/jmoiron/sqlx](https://github.com/jmoiron/sqlx) is chosen to connect to a database.
+1. [github.com/jmoiron/sqlx](https://github.com/jmoiron/sqlx) is chosen to connect to a database.
 
-12. [github.com/gorilla](https://github.com/gorilla) is chosen for a lot of the HTTP plumbings.
+1. [github.com/gorilla](https://github.com/gorilla) is chosen for a lot of the HTTP plumbings.
 
-13. [github.com/carbocation/interpose](https://github.com/carbocation/interpose) is chosen as the middleware library.
+1. [github.com/carbocation/interpose](https://github.com/carbocation/interpose) is chosen as the middleware library.
 
-14. [github.com/tylerb/graceful](https://github.com/tylerb/graceful) is chosen to enable graceful shutdown.
+1. [github.com/tylerb/graceful](https://github.com/tylerb/graceful) is chosen to enable graceful shutdown.
 
-15. [github.com/rnubel/pgmgr](https://github.com/rnubel/pgmgr) is chosen as the database migration and management tool for PostgreSQL.
+1. [github.com/rnubel/pgmgr](https://github.com/rnubel/pgmgr) is chosen as the database migration and management tool for PostgreSQL.
 
-16. [github.com/mattes/migrate](https://github.com/mattes/migrate) is chosen as the database migration and management tool for MySQL.
+1. [github.com/mattes/migrate](https://github.com/mattes/migrate) is chosen as the database migration and management tool for MySQL.
 
-17. [github.com/Sirupsen/logrus](https://github.com/Sirupsen/logrus) is chosen as the logging library.
+1. [github.com/Sirupsen/logrus](https://github.com/Sirupsen/logrus) is chosen as the logging library.
 
-18. [github.com/spf13/viper](https://github.com/spf13/viper) is chosen to manage application config.
+1. [github.com/spf13/viper](https://github.com/spf13/viper) is chosen to manage application config.


### PR DESCRIPTION
This commit updates the ordered lists in the README to use the "lazy list" numbering, as described in the [markdown syntax spec](https://daringfireball.net/projects/markdown/syntax#list). This way, you can add and remove elements from any point in the list without having to renumber all of the subsequent list elements.